### PR TITLE
Added CloudLinux Support

### DIFF
--- a/check_updates
+++ b/check_updates
@@ -906,6 +906,7 @@ sub get_updater {
     if (   $name =~ /Fedora/mxs
         || $name =~ /CentOS/mxs
         || $name =~ /PUIAS/mxs
+        || $name =~ /CloudLinux/mxs
         || $name =~ /Scientific[ ]Linux/mxs
         || $name =~ /Red[ ]Hat.*[ ][567]/mxs
         || $name =~ /Oracle/mxs


### PR DESCRIPTION
Added support check check CloudLinux also.

Cloudlinux is CentOS based os with some extra features from it's developers, if uses yum and this plugin works without issues with it, only issues is that it was unable to detect CloudLinux as distro.