### PR TITLE
Fixed line parsing. Added yum clean cache step

### DIFF
--- a/check_updates
+++ b/check_updates
@@ -531,6 +531,10 @@ sub run_yum {
             if ( $line =~ m/^[ ]/mxs ) {
                 next;
             }
+            
+            if ( $line =~ /^Obsoleting/i ) {
+                next;
+            }
 
             $line =~ s{[ ].*}{}mxs;
 
@@ -613,6 +617,11 @@ sub check_yum {
     my $message;
 
     check_security_option();
+
+    system("$yum_executable -q clean all");
+    if ( $? == -1) {
+      exit_with_error( UNKNOWN, "Cannot clean yum cache" );
+    }
 
     my @outdated = run_yum($arguments);
     my @security_updates;


### PR DESCRIPTION
In some cases there are obsolete packages reported in the `yum --security check-update` command output. This causes the `check_updates` script to count the word "Obsoleting" as a package. This PR fixes the line parsing and also adds an additional step to clean yum cache before the actual yum check.

Example:
```
$ yum --security check-update
Obsoleting Packages
mpich.i686                                                         3.1-4.el6                                                     base   
    mpich2.x86_64                                                  1.2.1-2.3.el6                                                 @base  
mpich-devel.i686                                                   3.1-4.el6                                                     base   
    mpich2-devel.x86_64                                            1.2.1-2.3.el6                                                 @base  
```
```
$ check_updates --security-only
Obsoleting (security)
mpich.i686 (security)
mpich-devel.i686 (security)
```