### PR TITLE
Update the Free Software Foundation address

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -12,4 +12,4 @@ General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.


### PR DESCRIPTION
Problem:
The old FSF address is being flagged as error by rpmlint:
$ rpmlint nagios-plugins-check-updates-1.6.18-1.fc25.x86_64.rpm
...
nagios-plugins-check-updates.x86_64: E: incorrect-fsf-address /usr/share/doc/nagios-plugins-check-updates/COPYRIGHT
...

Solution:
Use the new FSF address listed in https://www.fsf.org/about/contact/.

How to reproduce the rpmlint error:
$ lftpget https://kojipkgs.fedoraproject.org//packages/nagios-plugins-check-updates/1.6.18/1.fc25/x86_64/nagios-plugins-check-updates-1.6.18-1.fc25.x86_64.rpm

$ rpmlint nagios-plugins-check-updates-1.6.18-1.fc25.x86_64.rpm
...
nagios-plugins-check-updates.x86_64: E: incorrect-fsf-address /usr/share/doc/nagios-plugins-check-updates/COPYRIGHT
...

Additional information:
$ rpmlint -I incorrect-fsf-address
incorrect-fsf-address:
The Free Software Foundation address in this file seems to be outdated or
misspelled.  Ask upstream to update the address, or if this is a license file,
possibly the entire file with a new copy available from the FSF.