### PR TITLE
Add new types of kernel: kernel-lt, kernel-ml

### DIFF
--- a/check_updates
+++ b/check_updates
@@ -338,9 +338,10 @@ sub clean_kernel_version {
     # remove UEK
     $kernel =~ s/uek-//imxs;
 
-    # remove ml-aufs, lt-aufs
-    $kernel =~ s/ml-aufs-//imxs;
-    $kernel =~ s/lt-aufs-//imxs;
+    # remove ml, lt, aufs
+    $kernel =~ s/ml-//imxs;
+    $kernel =~ s/lt-//imxs;
+    $kernel =~ s/aufs-//imxs;
 
     return $kernel;
 
@@ -388,7 +389,8 @@ sub check_running_kernel {
             "$package-PAE",     "$package-xen",
             "$package-uek",     'ovzkernel',
             'vzkernel',         "$package-PAE-core",
-            "$package-ml-aufs", "$package-lt-aufs",
+            "$package-ml",      "$package-ml-aufs",
+	    "$package-lt",      "$package-lt-aufs",
             "$package-core",
         )
       )


### PR DESCRIPTION
Necessary to recognize kernel-lt and kernel-ml package for Centos 6, otherwise fails with message like:
<pre>
CHECK_UPDATES CRITICAL - your machine is running kernel 4.18.16-1 but a newer version (2.6.32-754.6.3) is installed: you should reboot, no updates available | total_updates=0;0;0 security_updates=0;0;0</pre>