### PR TITLE
Support Azure CentOS Virtualization SIG kernels

### DIFF
--- a/check_updates
+++ b/check_updates
@@ -343,8 +343,8 @@ sub clean_kernel_version {
     $kernel =~ s/lt-//imxs;
     $kernel =~ s/aufs-//imxs;
 
-    # remove azure
-    $kernel =~ s/[.]azure//imxs;
+    # Remove azure
+    $kernel =~ s/azure-//imxs;
 
     return $kernel;
 
@@ -394,7 +394,7 @@ sub check_running_kernel {
             'vzkernel',     "$package-PAE-core",
             "$package-ml",  "$package-ml-aufs",
             "$package-lt",  "$package-lt-aufs",
-            "$package-core",
+            "$package-azure", "$package-core",
         )
       )
 

--- a/check_updates
+++ b/check_updates
@@ -343,6 +343,9 @@ sub clean_kernel_version {
     $kernel =~ s/lt-//imxs;
     $kernel =~ s/aufs-//imxs;
 
+    # remove azure
+    $kernel =~ s/[.]azure//imxs;
+
     return $kernel;
 
 }


### PR DESCRIPTION
### Intent
For CentOS hosts running on Azure, the `kernel-azure` package can replace the kernel.  `check_updates` Nagios plugin failed to detect the new kernel.  These kernels are provided at http://mirror.centos.org/centos/7/virt/x86_64/azure/ 

### Before
```
$ uname -r
3.10.0-957.12.1.el7.azure.x86_64

$ perl check_updates
CHECK_UPDATES UNKNOWN - Unable to detect installed kernel
```

### Testing
```
$ perl check_updates
CHECK_UPDATES CRITICAL - 1 non-security update available | total_updates=1;0;0 security_updates=0;0;0
docker-ce-cli.x86_64
```
