### PR TITLE
Fix "bad interpreter" error.

### DIFF
--- a/check_updates
+++ b/check_updates
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 # nagios: -epn
 


### PR DESCRIPTION
## Fixes :
* [X] `perl: bad interpreter: No such file or directory`

When I run this script in my **CentOS 7** system, I had the following error :

```
/usr/lib64/nagios/plugins/check_updates -h
-bash: /usr/lib64/nagios/plugins/check_updates: perl: bad interpreter: No such file or directory
```

I had to run it as follows to avoid the above error:
```
perl check_updates -h
```


* Running on CentOS Linux release 7.9.2009 (Core)
* Linux kernel: 3.10.0-1160.42.2

## Proposed Changes

  - shebang line
