### PR TITLE
Move code defining 'quiet' option so it's actually available

### DIFF
--- a/check_updates
+++ b/check_updates
@@ -1049,8 +1049,7 @@ sub run {
 
     $options->arg(
         spec => 'quiet',
-        help =>
-'don\'t list updates, output only the status line',
+        help => 'Do not print package list',
     );
 
     $options->getopts();
@@ -1159,11 +1158,6 @@ sub run {
     if ( -e '/etc/yum/pluginconf.d/foreman-protector.conf' ) {
         $arguments = "$arguments --disableplugin=foreman-protector";
     }
-
-    $options->arg(
-        spec => 'quiet',
-        help => 'Do not print package list',
-    );
 
     #########
     # Timeout

--- a/check_updates
+++ b/check_updates
@@ -1047,6 +1047,12 @@ sub run {
 'consider the number of updates only (security updates are not automatically critical)',
     );
 
+    $options->arg(
+        spec => 'quiet',
+        help =>
+'don\'t list updates, output only the status line',
+    );
+
     $options->getopts();
 
     my $debug_file = $options->get('debug-file');


### PR DESCRIPTION
It seems that the code that defines 'quiet' options has been misplaced in code, so it doesn't get listed in help nor is it recognized.

Moving that block to the ' # Command line arguments' section fixes that.
